### PR TITLE
Add tracing spans to diff / decode / encode

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 pixelmatch-rs = { git = "https://github.com/bokuweb/pixelmatch-rs.git" }
 image = { version = "0.25.0", default-features = false, features=["gif", "jpeg", "png", "tiff", "bmp"] }
 thiserror = "2.0"
+tracing = "0.1"
 
 [build-dependencies]
 cc = "1.0"

--- a/core/src/decoder.rs
+++ b/core/src/decoder.rs
@@ -12,19 +12,36 @@ pub fn decode_buf(buf: &[u8]) -> Result<DecodeOutput, ImageDiffError> {
     match buf {
         // RIFF .... WEBP
         [b'R', b'I', b'F', b'F', _, _, _, _, b'W', b'E', b'B', b'P', ..] => {
+            let _span = tracing::info_span!("decode_webp", bytes = buf.len()).entered();
             Ok(decode_webp_buf(buf).map_err(|_| {
                 ImageDiffError::Decode(("Failed to decode as webp format").to_string())
             })?)
         }
         _ => {
-            let i = image::load_from_memory(buf);
-            if let Ok(opened) = i {
-                Ok(DecodeOutput {
-                    dimensions: opened.dimensions(),
-                    buf: opened.to_rgba8().to_vec(),
-                })
-            } else {
-                Err(ImageDiffError::Decode(i.unwrap_err().to_string()))
+            let _span = tracing::info_span!("decode_image_crate", bytes = buf.len()).entered();
+
+            let opened = {
+                let _s = tracing::info_span!("load_from_memory").entered();
+                image::load_from_memory(buf)
+            };
+            match opened {
+                Ok(img) => {
+                    let dims = img.dimensions();
+                    let buf_rgba = {
+                        let _s = tracing::info_span!(
+                            "to_rgba8",
+                            width = dims.0,
+                            height = dims.1
+                        )
+                        .entered();
+                        img.to_rgba8().to_vec()
+                    };
+                    Ok(DecodeOutput {
+                        dimensions: dims,
+                        buf: buf_rgba,
+                    })
+                }
+                Err(e) => Err(ImageDiffError::Decode(e.to_string())),
             }
         }
     }

--- a/core/src/encoder.rs
+++ b/core/src/encoder.rs
@@ -6,5 +6,12 @@ pub struct EncodeOutput {
 }
 
 pub fn encode(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, ImageDiffError> {
+    let _span = tracing::info_span!(
+        "encode_webp_ffi",
+        width,
+        height,
+        rgba_bytes = rgba.len()
+    )
+    .entered();
     encode_webp(rgba, width, height)
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,28 +39,64 @@ pub fn diff(
     expected: impl AsRef<[u8]>,
     option: &DiffOption,
 ) -> Result<DiffOutput, ImageDiffError> {
+    let _span = tracing::info_span!(
+        "image_diff",
+        actual_bytes = actual.as_ref().len(),
+        expected_bytes = expected.as_ref().len()
+    )
+    .entered();
+
     if actual.as_ref() == expected.as_ref() {
+        let _s = tracing::info_span!("image_diff.short_circuit_eq").entered();
         return Ok(DiffOutput::Eq);
     }
-    let img1 = decode_buf(actual.as_ref())?;
-    let img2 = decode_buf(expected.as_ref())?;
+
+    let img1 = {
+        let _s = tracing::info_span!(
+            "decode_actual",
+            bytes = actual.as_ref().len()
+        )
+        .entered();
+        decode_buf(actual.as_ref())?
+    };
+    let img2 = {
+        let _s = tracing::info_span!(
+            "decode_expected",
+            bytes = expected.as_ref().len()
+        )
+        .entered();
+        decode_buf(expected.as_ref())?
+    };
 
     let w = std::cmp::max(img1.dimensions.0, img2.dimensions.0);
     let h = std::cmp::max(img1.dimensions.1, img2.dimensions.1);
 
-    // expand ig size is not match.
-    let expanded1 = expander::expand(img1.buf, img1.dimensions, w, h);
-    let expanded2 = expander::expand(img2.buf, img2.dimensions, w, h);
+    // expand if size is not match.
+    let (expanded1, expanded2) = {
+        let _s = tracing::info_span!("expand", width = w, height = h).entered();
+        let e1 = expander::expand(img1.buf, img1.dimensions, w, h);
+        let e2 = expander::expand(img2.buf, img2.dimensions, w, h);
+        (e1, e2)
+    };
 
-    let result = compare_buf(
-        &expanded1,
-        &expanded2,
-        (w, h),
-        CompareOption {
-            threshold: option.threshold.unwrap_or_default(),
-            enable_anti_alias: option.include_anti_alias.unwrap_or_default(),
-        },
-    )?;
+    let result = {
+        let _s = tracing::info_span!(
+            "compare_pixels",
+            width = w,
+            height = h,
+            pixels = (w as u64) * (h as u64)
+        )
+        .entered();
+        compare_buf(
+            &expanded1,
+            &expanded2,
+            (w, h),
+            CompareOption {
+                threshold: option.threshold.unwrap_or_default(),
+                enable_anti_alias: option.include_anti_alias.unwrap_or_default(),
+            },
+        )?
+    };
 
     match result {
         DiffOutput::NotEq {
@@ -68,12 +104,24 @@ pub fn diff(
             diff_image,
             width,
             height,
-        } => Ok(DiffOutput::NotEq {
-            diff_count,
-            diff_image: encode(&diff_image, width, height)?,
-            width,
-            height,
-        }),
+        } => {
+            let encoded = {
+                let _s = tracing::info_span!(
+                    "encode_diff_webp",
+                    width = width,
+                    height = height,
+                    diff_count
+                )
+                .entered();
+                encode(&diff_image, width, height)?
+            };
+            Ok(DiffOutput::NotEq {
+                diff_count,
+                diff_image: encoded,
+                width,
+                height,
+            })
+        }
         DiffOutput::Eq => Ok(DiffOutput::Eq),
     }
 }


### PR DESCRIPTION
## Summary

- Adds the `tracing` crate as a dependency and instrumentation spans to `diff()`, `decode_buf()`, and `encode()`.
- Downstream consumers running a `tracing-subscriber` layer (e.g. OpenTelemetry → Jaeger) can now see the internal breakdown of a single `diff()` call.

## New span tree

```
image_diff                       (root of diff())
├─ decode_actual / decode_expected
│  ├─ decode_image_crate         (PNG / JPEG / GIF / BMP / TIFF)
│  │  ├─ load_from_memory        (image::load_from_memory)
│  │  └─ to_rgba8                (dimensions → Vec<u8>)
│  └─ decode_webp                (custom libwebp path)
├─ expand                        (when sizes mismatch)
├─ compare_pixels                (pixelmatch)
└─ encode_diff_webp
   └─ encode_webp_ffi
```

## Motivation

During a trace comparison between `reg-cli` JS and `reg-cli` Wasm, we wanted to confirm whether PNG decode or pixel comparison was the dominant cost. Without these spans, the entire diff appeared as one opaque chunk from Rust — span coverage stopped at `image-diff-rs`'s public API.

With this patch, the breakdown (20 images × 1280×720) became visible:

| span | Σ duration (across 4 parallel workers) |
|---|---:|
| decode_image_crate (PNG) | 77 ms |
| compare_pixels (pixelmatch) | 497 ms |
| encode_webp_ffi | 342 ms |

i.e. the decode step that was hypothesized to dominate turned out to be ~8% of total. This was only discoverable because we could see inside `diff()`.

## Overhead

`tracing` macros compile down to no-ops when no subscriber is registered, so callers that don't use tracing should see no measurable change.

## Test plan

- [x] `cargo check` passes
- [x] Builds for `wasm32-wasip1-threads` (used downstream in reg-cli)
- [x] Spans visible in Jaeger when a downstream `tracing-subscriber` is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)